### PR TITLE
Anonymous and inline class declaration syntax highlighting broken

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -60,7 +60,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(new)\s+(\w+(?:\.\w*)*)</string>
+			<string>(new)\s+((?!class)\w+(?:\.\w*)*)</string>
 			<key>name</key>
 			<string>meta.class.instance.constructor</string>
 		</dict>

--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -422,7 +422,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(class\b)\s+(@?[a-zA-Z\$_][\w\.]*)?(?:\s+(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?</string>
+			<string>(class\b)\s+((?!extends)@?[a-zA-Z\$_][\w\.]*)?(?:\s*(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?</string>
 			<key>name</key>
 			<string>meta.class.coffee</string>
 		</dict>

--- a/CoffeeScript_Literate.tmLanguage
+++ b/CoffeeScript_Literate.tmLanguage
@@ -588,7 +588,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(new)\s+(\w+(?:\.\w*)*)</string>
+					<string>(new)\s+((?!class)\w+(?:\.\w*)*)</string>
 					<key>name</key>
 					<string>meta.class.instance.constructor</string>
 				</dict>

--- a/CoffeeScript_Literate.tmLanguage
+++ b/CoffeeScript_Literate.tmLanguage
@@ -917,7 +917,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(class\b)\s+(@?[a-zA-Z\$_][\w\.]*)?(?:\s+(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?</string>
+					<string>(class\b)\s+((?!extends)@?[a-zA-Z\$_][\w\.]*)?(?:\s*(extends)\s+(@?[a-zA-Z\$\._][\w\.]*))?</string>
 					<key>name</key>
 					<string>meta.class.coffee</string>
 				</dict>


### PR DESCRIPTION
As seen here:

![image](https://cloud.githubusercontent.com/assets/980096/9206627/f74c699a-4036-11e5-9d01-8e1a17037475.png)

All those class declarations are valid coffeescript, but only the last is highlighted.

Code shown above for reference:
```
foo = new class extends Bar
    constructor: ->
        # sadness :(

foo = new class Baz extends Bar
    constructor: ->
        # also broken

foo = new (class extends Bar
    constructor: ->
        # parenthesizes alone don't fix it
)

foo = new (class Baz extends Bar
    constructor: ->
        # but naming + parenthesizes do
)
``` 